### PR TITLE
Calibration process changed: now it uses I2C instead of GPIO. Tested.

### DIFF
--- a/AS5600_HAL_Library/main/as5600_lib.c
+++ b/AS5600_HAL_Library/main/as5600_lib.c
@@ -10,12 +10,6 @@ void AS5600_Init(AS5600_t *as5600, i2c_port_t i2c_num, uint8_t scl, uint8_t sda,
         return;
     }
 
-    ///< GPIO configuration for the OUT pin. Read page 23 of the AS5600 datasheet to undertand the calibration process.
-    if (!gpio_init_basic(&as5600->gpio_handle, out, 2, false, false)) {
-        printf("GPIO initialization failed");
-        return;
-    }
-    gpio_set_low(&as5600->gpio_handle); // Set the GPIO to low (calibration process)
 }
 
 void AS5600_Deinit(AS5600_t *as5600)


### PR DESCRIPTION
As discussed in the meeting, we will use the I2C interface to calibrate the AS5600 sensor instead of relying on GPIO.

Let’s remember that using GPIO requires recalibrating the sensor every time the system is powered on, which is quite cumbersome.

The goal of this new approach is to retrieve the values stored in the ZPOS (initial position) and MPOS (maximum position) registers, save them, and reuse them whenever the sensor is initialized. This way, calibration is only required once.